### PR TITLE
Updating Client Authentication version since v1alpha1 no longer exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.15-buster as dev
+FROM golang:1.19-buster as dev
 
 # Download packr binary
-RUN go get -u github.com/gobuffalo/packr/packr2
+RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
 
 WORKDIR $GOPATH/src/github.com/bfmiv/klarista
 
@@ -11,7 +11,7 @@ RUN go mod download
 
 COPY . .
 
-FROM golang:1.15-buster as build
+FROM golang:1.19-buster as build
 
 ARG KLARISTA_CLI_VERSION
 ENV KLARISTA_CLI_VERSION ${KLARISTA_CLI_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export DOCKER_BRANCH_TAG = '$(GIT_BRANCH)$(if $(GIT_DIRTY),--DIRTY)'
 export DOCKER_COMMIT_TAG = '$(GIT_COMMIT)$(if $(GIT_DIRTY),--DIRTY)'
 export DOCKER_IMAGE      = "bernardmcmanus/klarista"
 
-export KLARISTA_CLI_VERSION               = '0.18.2'
+export KLARISTA_CLI_VERSION               = '0.18.3'
 export KLARISTA_CLI_VERSION_TAG           = '$(KLARISTA_CLI_VERSION)$(if $(GIT_DIRTY),--DIRTY)'
 export KLARISTA_CLI_VERSION_ALIAS_TAG = '$(shell awk 'BEGIN { FS = "." } ; { print $$1 "." $$2 }' <<< '$(KLARISTA_CLI_VERSION)')$(if $(GIT_DIRTY),--DIRTY)'
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,6 +27,8 @@ var createCmd = &cobra.Command{
 		yes, _ := cmd.Flags().GetBool("yes")
 		autoFlags := getAutoFlags(yes)
 
+		clientAuthAPIVersion, _ := cmd.Flags().GetString("client-authentication-api-version")
+
 		pwd, err := os.Getwd()
 		if err != nil {
 			panic(err)
@@ -441,7 +443,7 @@ var createCmd = &cobra.Command{
 							Name: name,
 							User: KubernetesUserUser{
 								Exec: &map[string]interface{}{
-									"apiVersion": "client.authentication.k8s.io/v1alpha1",
+									"apiVersion": clientAuthAPIVersion,
 									"args": []string{
 										"token",
 										"-i",
@@ -515,4 +517,5 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 	createCmd.Flags().Bool("fast", false, "Apply updates as quickly as possible. This is not safe in production")
 	createCmd.Flags().Bool("yes", false, "Skip confirmation")
+	createCmd.Flags().String("client-authentication-api-version", "client.authentication.k8s.io/v1beta1", "Version of the Kubernetes Client Authentication API to use when generating the Kubeconfig file")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -416,50 +416,7 @@ var createCmd = &cobra.Command{
 				}
 
 				// Build cluster kubeconfig
-				kubeconfig := KubernetesConfig{
-					ApiVersion:     "v1",
-					CurrentContext: name,
-					Kind:           "Config",
-					Preferences:    map[string]interface{}{},
-					Clusters: []KubernetesCluster{
-						{
-							Cluster: KubernetesClusterCluster{
-								Server: "https://api." + name,
-							},
-							Name: name,
-						},
-					},
-					Contexts: []KubernetesContext{
-						{
-							Context: KubernetesContextContext{
-								Cluster: name,
-								User:    name,
-							},
-							Name: name,
-						},
-					},
-					Users: []KubernetesUser{
-						{
-							Name: name,
-							User: KubernetesUserUser{
-								Exec: &map[string]interface{}{
-									"apiVersion": clientAuthAPIVersion,
-									"args": []string{
-										"token",
-										"-i",
-										name,
-										"-r",
-										awsIamClusterAdminRoleArn,
-									},
-									"command":            "aws-iam-authenticator",
-									"env":                nil,
-									"interactiveMode":    "IfAvailable",
-									"provideClusterInfo": false,
-								},
-							},
-						},
-					},
-				}
+				kubeconfig := generateKubeconfig(name, clientAuthAPIVersion, awsIamClusterAdminRoleArn)
 
 				var kubeconfigBytes []byte
 				if kubeconfigBytes, err = yaml.Marshal(kubeconfig); err != nil {

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -40,3 +40,50 @@ type KubernetesConfig struct {
 	Preferences    map[string]interface{} `json:"preferences"`
 	Users          []KubernetesUser       `json:"users"`
 }
+
+func generateKubeconfig(clusterName string, clientAuthenticationAPIVersion string, awsIAMRoleName string) KubernetesConfig {
+	return KubernetesConfig{
+		ApiVersion:     "v1",
+		CurrentContext: clusterName,
+		Kind:           "Config",
+		Preferences:    map[string]interface{}{},
+		Clusters: []KubernetesCluster{
+			{
+				Cluster: KubernetesClusterCluster{
+					Server: "https://api." + clusterName,
+				},
+				Name: clusterName,
+			},
+		},
+		Contexts: []KubernetesContext{
+			{
+				Context: KubernetesContextContext{
+					Cluster: clusterName,
+					User:    clusterName,
+				},
+				Name: clusterName,
+			},
+		},
+		Users: []KubernetesUser{
+			{
+				Name: clusterName,
+				User: KubernetesUserUser{
+					Exec: &map[string]interface{}{
+						"apiVersion": clientAuthenticationAPIVersion,
+						"args": []string{
+							"token",
+							"-i",
+							clusterName,
+							"-r",
+							awsIAMRoleName,
+						},
+						"command":            "aws-iam-authenticator",
+						"env":                nil,
+						"interactiveMode":    "IfAvailable",
+						"provideClusterInfo": false,
+					},
+				},
+			},
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,47 @@
 module github.com/bfmiv/klarista
 
-go 1.15
+go 1.19
 
 require (
-	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/aws/aws-sdk-go v1.35.23
 	github.com/ghodss/yaml v1.0.0
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/gobwas/glob v0.2.3
-	github.com/golang/snappy v0.0.4 // indirect
-	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
-	github.com/klauspost/compress v1.15.8 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mholt/archiver/v3 v3.5.1
-	github.com/nwaples/rardecode v1.1.3 // indirect
-	github.com/pierrec/lz4/v4 v4.1.15 // indirect
-	github.com/rogpeppe/go-internal v1.6.0 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stevenle/topsort v0.2.0
 	github.com/thanhpk/randstr v1.0.4
 	github.com/thoas/go-funk v0.7.0
+)
+
+require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/gobuffalo/logger v1.0.3 // indirect
+	github.com/gobuffalo/packd v1.0.0 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
+	github.com/karrick/godirwalk v1.15.3 // indirect
+	github.com/klauspost/compress v1.15.8 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/markbates/errx v1.1.0 // indirect
+	github.com/markbates/oncer v1.0.0 // indirect
+	github.com/markbates/safe v1.0.1 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/nwaples/rardecode v1.1.3 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
+	github.com/rogpeppe/go-internal v1.6.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )


### PR DESCRIPTION
Updating Go version to latest 1.19
Bumping CLI version to 1.18.3
Updating go.mod to the latest format including transitive dependencies Keeping a client-authentication-api-version flag on the create command for backwwards and forwards compatibility as the apiVersion changes